### PR TITLE
fix: replace invalid /raindrops endpoint with /raindrops/0

### DIFF
--- a/src/services/raindrop.service.ts
+++ b/src/services/raindrop.service.ts
@@ -468,7 +468,7 @@ class RaindropService {
       delete queryParams.createdEnd;
     }
     
-    const { data } = await this.api.get('/raindrops', { 
+    const { data } = await this.api.get('/raindrops/0', { 
       params: queryParams 
     });
     


### PR DESCRIPTION
## 🐛 Problem

The `bookmark_search` tool was returning 404 errors because the `searchRaindrops` method was calling an invalid `/raindrops` endpoint.

## 🔧 Solution

Changed the endpoint from `/raindrops` to `/raindrops/0` in the `searchRaindrops` method, aligning it with the working `getBookmarks` implementation.

## ✅ Testing

- Built and tested locally with Cursor MCP integration
- Verified `bookmark_search` now returns results instead of 404 errors
- Confirmed other MCP tools remain functional
- No regression in existing functionality

## 📝 Changes

- `src/services/raindrop.service.ts`: Line 471 - Changed `/raindrops` to `/raindrops/0`

This fix makes the bookmark search functionality work as expected and aligns with the Raindrop.io API documentation.