### PR TITLE
fix(bookmarks): pass collectionId through update handler

### DIFF
--- a/src/tools/bookmarks.ts
+++ b/src/tools/bookmarks.ts
@@ -164,6 +164,11 @@ const bookmarkManageTool = defineTool({
         setIfDefined(updatePayload, "excerpt", args.description);
         setIfDefined(updatePayload, "tags", args.tags);
         setIfDefined(updatePayload, "important", args.important);
+        // Raindrop API expects collection moves as a nested object.
+        // See: https://developer.raindrop.io/v1/raindrops/single#update-raindrop
+        if (args.collectionId !== undefined) {
+          updatePayload.collection = { $id: args.collectionId };
+        }
         return raindropService.updateBookmark(args.id, updatePayload as any);
       }
       case "delete": {

--- a/tests/bookmark_manage.test.ts
+++ b/tests/bookmark_manage.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { bookmarkTools } from "../src/tools/bookmarks.js";
+import type { ToolHandlerContext } from "../src/tools/common.js";
+
+// Pull the bookmark_manage handler out of the exported tool list.
+const bookmarkManageTool = bookmarkTools.find(
+  (t: any) => t.name === "bookmark_manage",
+)!;
+
+function makeContext(serviceOverrides: Partial<any> = {}): ToolHandlerContext {
+  const raindropService = {
+    createBookmark: vi.fn(),
+    updateBookmark: vi.fn().mockResolvedValue({ _id: 1 }),
+    deleteBookmark: vi.fn().mockResolvedValue(undefined),
+    ...serviceOverrides,
+  };
+  return {
+    raindropService: raindropService as any,
+    mcpServer: {},
+  };
+}
+
+describe("bookmark_manage tool — update", () => {
+  let ctx: ToolHandlerContext;
+
+  beforeEach(() => {
+    ctx = makeContext();
+  });
+
+  it("maps collectionId into the nested {collection: {$id}} shape the Raindrop API expects", async () => {
+    await (bookmarkManageTool as any).handler(
+      {
+        operation: "update",
+        id: 123,
+        url: "https://example.com",
+        title: "Example",
+        collectionId: 99,
+      },
+      ctx,
+    );
+
+    const updateSpy = (ctx.raindropService as any).updateBookmark;
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const [id, payload] = updateSpy.mock.calls[0];
+    expect(id).toBe(123);
+    expect(payload.collection).toEqual({ $id: 99 });
+  });
+
+  it("omits collection from the payload when collectionId is not provided", async () => {
+    await (bookmarkManageTool as any).handler(
+      {
+        operation: "update",
+        id: 123,
+        url: "https://example.com",
+        title: "Example",
+        tags: ["a", "b"],
+      },
+      ctx,
+    );
+
+    const updateSpy = (ctx.raindropService as any).updateBookmark;
+    const [, payload] = updateSpy.mock.calls[0];
+    expect(payload).not.toHaveProperty("collection");
+    expect(payload.tags).toEqual(["a", "b"]);
+  });
+
+  it("preserves other fields alongside a collection move", async () => {
+    await (bookmarkManageTool as any).handler(
+      {
+        operation: "update",
+        id: 5,
+        url: "https://example.com/x",
+        title: "New title",
+        tags: ["updated"],
+        important: true,
+        collectionId: 42,
+      },
+      ctx,
+    );
+
+    const updateSpy = (ctx.raindropService as any).updateBookmark;
+    const [, payload] = updateSpy.mock.calls[0];
+    expect(payload).toMatchObject({
+      link: "https://example.com/x",
+      title: "New title",
+      tags: ["updated"],
+      important: true,
+      collection: { $id: 42 },
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`bookmark_manage` with `operation: update` accepted a `collectionId` argument but never forwarded it to the Raindrop API. The update payload was built without a `collection` field, so any "move bookmark to another collection" request silently no-op'd — the bookmark stayed in its original collection with no error.

## Root cause

In `src/tools/bookmarks.ts`, the `update` case built `updatePayload` from `link`, `title`, `excerpt`, `tags`, and `important` — but never mapped `args.collectionId` into the `{collection: {$id}}` shape that the [Raindrop API expects](https://developer.raindrop.io/v1/raindrops/single#update-raindrop).

## Fix

Five lines added to the `update` case:

```ts
if (args.collectionId !== undefined) {
  updatePayload.collection = { $id: args.collectionId };
}
```

This mirrors what the `create` case already does (passing `collectionId` directly to `createBookmark`).

## Tests

Three new unit tests in `tests/bookmark_manage.test.ts`:

1. **Maps `collectionId` into `{collection: {$id}}`** — verifies the API receives the nested shape.
2. **Omits `collection` when `collectionId` is absent** — no regression for plain metadata-only updates.
3. **Preserves other fields alongside a collection move** — `tags`, `important`, `title`, `link`, and `collection` all present together.

All three tests pass (`bun run test`).